### PR TITLE
Fix 1000 client

### DIFF
--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -661,7 +661,7 @@ class AWSBucket(WazuhIntegration):
         try:
             time_mark = datetime.strftime(datetime.utcnow(), "%Y%m%d--%I-%M-%S")
             ### copy database before
-            shutil.copy('/var/ossec/wodles/aws/s3_cloudtrail.db', '/var/ossec/wodles/aws/s3_cloudtrail_{}.db'.format(time_mark))
+            shutil.copy('/var/ossec/wodles/aws/s3_cloudtrail.db', '/var/ossec/wodles/aws/s3_cloudtrail_{}_{}.db'.format(aws_region, time_mark))
             bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, aws_region))
 
             if 'Contents' not in bucket_files:

--- a/wodles/aws/aws-s3.py
+++ b/wodles/aws/aws-s3.py
@@ -74,6 +74,12 @@ from time import mktime
 if sys.version_info[0] == 3:
     unicode = str
 
+##### DEBUG VERSION
+import shutil
+import logging
+
+logging.basicConfig(filename='/var/ossec/wodles/aws/aws.log', filemode='a', level=logging.CRITICAL)
+
 
 ################################################################################
 # Constants
@@ -653,6 +659,9 @@ class AWSBucket(WazuhIntegration):
 
     def iter_files_in_bucket(self, aws_account_id, aws_region):
         try:
+            time_mark = datetime.strftime(datetime.utcnow(), "%Y%m%d--%I-%M-%S")
+            ### copy database before
+            shutil.copy('/var/ossec/wodles/aws/s3_cloudtrail.db', '/var/ossec/wodles/aws/s3_cloudtrail_{}.db'.format(time_mark))
             bucket_files = self.client.list_objects_v2(**self.build_s3_filter_args(aws_account_id, aws_region))
 
             if 'Contents' not in bucket_files:
@@ -670,6 +679,9 @@ class AWSBucket(WazuhIntegration):
                     else:
                         debug("++ Skipping previously processed file: {file}".format(file=bucket_file['Key']), 1)
                         continue
+
+                ##### logger
+                logging.critical('- {} - LOG TO BE PROCESSED -> {}'.format(time_mark, bucket_file['Key']))
 
                 debug("++ Found new log: {0}".format(bucket_file['Key']), 2)
                 # Get the log file from S3 and decompress it


### PR DESCRIPTION
# QA Standard pull request template

**IMPORTANT: Please do not create a Pull Request without creating an issue first.**
*Any change needs to be discussed before proceeding. Failure to do so may result in the rejection of the pull request.*

---

## Closing/Related Issues
Related with https://github.com/wazuh/wazuh-jenkins/issues/828


## Test plan (required)

I've created some PRs in an alternative Wazuh repository (fork) with the desired format for the parameters to be introduced by the user: https://github.com/okynos/wazuh/pull/3 

Here the results: 

- [PR](https://github.com/okynos/wazuh/pull/3 ) -- [BUILD](https://jenkins-staging.wazuh.info/job/PR_WAZUH_SCANBUILD/67/console)
```java
Scan build parameters: [
    custom_stress_script:
    #!/bin/sh

    while [ 0 = 0 ]; do
        docker run --rm hello-world &
        PID1=$!
        docker run --rm hello-world &
        PID2=$!
        wait $PID1
        wait $PID2
        sleep 2
    done
    , custom-flag:-enable-checker alpha.core.CastSize  -enable-checker alpha.core.CastToStruct -enable-checker alpha.core.Conversion -enable-checker alpha.core.IdenticalExpr , 
    parameter-with-scape: \"echo $var \| cut -d ' ' -f 1\" 
  ]
```


- [x] I have tested the pipeline on Jenkins. (Mandatory)
<!-- Test link on Jenkins -->

## Target Jenkins
- [x] Production
- [x] Staging

Are there dependencies with other repositories? (Remove unmark checks)
- [ ] Yes
- [x] No

Are there dependencies with other pipelines? (Remove unmark checks)
- [ ] Yes
- [x] No


## Documentation
- Link to Jenkins wiki page <here>.

## Description/Notes
<!-- 
Please provide enough information so that others can review your pull request:
You can skip this if you're fixing a typo or adding an app to the Showcase.
Explain the **details** for making this change. What existing problem does the pull request solve?
Example: When "Adding a function to do X", explain why it is necessary to have a way to do X. 
-->

# Custom scripts parameters
## scan-build:second_script_example
```
#!/bin/sh

while [ 0 = 0 ]; do
    docker run --rm hello-world &
    PID1=$!
    docker run --rm hello-world &
    PID2=$!
    wait $PID1
    wait $PID2
    sleep 2
 done

while [ 0 = 0 ]; do
    docker run --rm hello-world &
    PID1=$!
    docker run --rm hello-world &
    PID2=$!
    wait $PID1
    wait $PID2
    sleep 2
 done
```

# Testing Parameters
Module | Parameter  | Value  
--- | --- | --- 
scan-build|other-flag|-foobar
scan-build|other-flag|-asedeje
scan-build|parameter-with-scape| "echo $var \| cut -d ' ' -f 1" 

# Custom scripts parameters
## scan-build:custom_stress_script
```
#!/bin/sh

while [ 0 = 0 ]; do
    docker run --rm hello-world &
    PID1=$!
    docker run --rm hello-world &
    PID2=$!
    wait $PID1
    wait $PID2
    sleep 2
 done
```

# Testing Parameters
Module | Parameter  | Value  
--- | --- | --- 
scan-build|custom-flag|-enable-checker alpha.core.CastSize 
scan-build|custom-flag|-enable-checker alpha.core.CastToStruct
scan-build|custom-flag|-enable-checker alpha.core.Conversion
scan-build|custom-flag|-enable-checker alpha.core.IdenticalExpr 
scan-build|parameter-with-scape| "echo $var \| cut -d ' ' -f 1" 
valgrind|time| 12345
valgrind|custom-flag|​--track-origins=yes
valgrind|custom-flag|​--leak-check=full 
valgrind|custom-flag|--keep-stacktraces=alloc-and-free
valgrind|custom-flag|--show-leak-kinds=definite,indirect

